### PR TITLE
using apc to share metrics across php processes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "require": {
         "kelvinmo/simplejwt": "0.3.0",
-        "promphp/prometheus_client_php": "^2.2"
+        "promphp/prometheus_client_php": "^2.2",
+        "ext-apc": "^5.1"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b7cd91a3eddc903d2adce035daa0d659",
+    "content-hash": "137c151ce1eb7939bd4fbc5b7a3ee86b",
     "packages": [
         {
             "name": "kelvinmo/simplejwt",
@@ -214,7 +214,9 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "ext-apc": "^5.1"
+    },
     "platform-dev": [],
     "plugin-api-version": "2.0.0"
 }

--- a/src/applications/prometheus/application/PhabricatorPrometheusApplication.php
+++ b/src/applications/prometheus/application/PhabricatorPrometheusApplication.php
@@ -1,14 +1,14 @@
 <?php
 
 use Prometheus\CollectorRegistry;
-use Prometheus\Storage\InMemory as InMemoryStorage;
+use Prometheus\Storage\APC as APCStorage;
 
 final class PhabricatorPrometheusApplication extends PhabricatorApplication {
 
   private static $registry;
 
   public static function getRegistry(): CollectorRegistry {
-    return self::$registry ?? (self::$registry = new CollectorRegistry(new InMemoryStorage()));
+    return self::$registry ?? (self::$registry = new CollectorRegistry(new APCStorage()));
   }
 
   public function getName(): string {


### PR DESCRIPTION
State is not shared between php worker processes. APCu is a cache which is shared among php worker processes so updates from one process (sync repos etc.) should be available to the /metrics endpoint controller.