### PR TITLE
using redis storage for prometheus

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,6 @@
     "require": {
         "kelvinmo/simplejwt": "0.3.0",
         "promphp/prometheus_client_php": "^2.2",
-        "ext-apcu": "^5.1"
+        "ext-redis": "^3.1"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "adede2a8446ae657792114473ccfbddc",
+    "content-hash": "8e388d6dc0f77a90811311208f7d6e0e",
     "packages": [
         {
             "name": "kelvinmo/simplejwt",
@@ -215,7 +215,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "ext-apcu": "^5.1"
+        "ext-redis": "^3.1"
     },
     "platform-dev": [],
     "plugin-api-version": "2.0.0"

--- a/src/applications/prometheus/application/PhabricatorPrometheusApplication.php
+++ b/src/applications/prometheus/application/PhabricatorPrometheusApplication.php
@@ -1,14 +1,14 @@
 <?php
 
 use Prometheus\CollectorRegistry;
-use Prometheus\Storage\APC as APCStorage;
+use Prometheus\Storage\Redis as RedisStorage;
 
 final class PhabricatorPrometheusApplication extends PhabricatorApplication {
 
   private static $registry;
 
   public static function getRegistry(): CollectorRegistry {
-    return self::$registry ?? (self::$registry = new CollectorRegistry(new APCStorage()));
+    return self::$registry ?? (self::$registry = new CollectorRegistry(new RedisStorage()));
   }
 
   public function getName(): string {


### PR DESCRIPTION
The apcu adapter didn't seem to collect all the metrics. We theorise this is because the apcu was a cache across a php worker pool where some of the git recieve operations were spawning separate php pools. Pushing the metrics to a redis sidecar should collect all of them