### PR TITLE
Update php-redis version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,6 @@
     "require": {
         "kelvinmo/simplejwt": "0.3.0",
         "promphp/prometheus_client_php": "^2.2",
-        "ext-redis": "^4.3"
+        "ext-redis": "^5.3.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,6 @@
     "require": {
         "kelvinmo/simplejwt": "0.3.0",
         "promphp/prometheus_client_php": "^2.2",
-        "ext-redis": "^5.3.0"
+        "ext-redis": "^5.3.4"
     }
 }


### PR DESCRIPTION
The base image that phabricator builds upon has been upgraded from Alpine 3.10 to  3.14, and now the version of redis required is 5.3.0 https://repology.org/project/php:redis/versions