### PR TITLE
Bumped php-redis version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,6 @@
     "require": {
         "kelvinmo/simplejwt": "0.3.0",
         "promphp/prometheus_client_php": "^2.2",
-        "ext-redis": "^4.3"
+        "ext-redis": "^5.3.4"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "03ad673d1a81ee0cb8824a7b7250c4f1",
+    "content-hash": "b63413f26db5ad44935c307038516ea8",
     "packages": [
         {
             "name": "kelvinmo/simplejwt",
@@ -58,26 +58,29 @@
                 "JWE",
                 "jwt"
             ],
+            "support": {
+                "issues": "https://github.com/kelvinmo/simplejwt/issues",
+                "source": "https://github.com/kelvinmo/simplejwt/tree/v0.3.0"
+            },
             "time": "2020-06-15T21:47:11+00:00"
         },
         {
             "name": "promphp/prometheus_client_php",
-            "version": "v2.2.2",
+            "version": "v2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PromPHP/prometheus_client_php.git",
-                "reference": "5d27b6d84900d9b3208b5b6bf88d10ed0dc7a154"
+                "reference": "6e30c28d19acb65e5d9a445c8c9bdb11b0d56c73"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PromPHP/prometheus_client_php/zipball/5d27b6d84900d9b3208b5b6bf88d10ed0dc7a154",
-                "reference": "5d27b6d84900d9b3208b5b6bf88d10ed0dc7a154",
+                "url": "https://api.github.com/repos/PromPHP/prometheus_client_php/zipball/6e30c28d19acb65e5d9a445c8c9bdb11b0d56c73",
+                "reference": "6e30c28d19acb65e5d9a445c8c9bdb11b0d56c73",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "php": "^7.2|^8.0",
-                "symfony/polyfill-apcu": "^1.6"
+                "php": "^7.2|^8.0"
             },
             "replace": {
                 "endclothing/prometheus_client_php": "*",
@@ -91,12 +94,14 @@
                 "phpstan/phpstan-phpunit": "^0.12.16",
                 "phpstan/phpstan-strict-rules": "^0.12.5",
                 "phpunit/phpunit": "^8.4|^9.4",
-                "squizlabs/php_codesniffer": "^3.5"
+                "squizlabs/php_codesniffer": "^3.5",
+                "symfony/polyfill-apcu": "^1.6"
             },
             "suggest": {
                 "ext-apc": "Required if using APCu.",
                 "ext-redis": "Required if using Redis.",
-                "promphp/prometheus_push_gateway_php": "An easy client for using Prometheus PushGateway."
+                "promphp/prometheus_push_gateway_php": "An easy client for using Prometheus PushGateway.",
+                "symfony/polyfill-apcu": "Required if you use APCu on PHP8.0+"
             },
             "type": "library",
             "extra": {
@@ -120,67 +125,11 @@
                 }
             ],
             "description": "Prometheus instrumentation library for PHP applications.",
-            "time": "2021-03-05T08:54:14+00:00"
-        },
-        {
-            "name": "symfony/polyfill-apcu",
-            "version": "v1.22.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-apcu.git",
-                "reference": "bc9974e74f8c05f4ceb500b1e0603e36be7d8223"
+            "support": {
+                "issues": "https://github.com/PromPHP/prometheus_client_php/issues",
+                "source": "https://github.com/PromPHP/prometheus_client_php/tree/v2.3.0"
             },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-apcu/zipball/bc9974e74f8c05f4ceb500b1e0603e36be7d8223",
-                "reference": "bc9974e74f8c05f4ceb500b1e0603e36be7d8223",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.22-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Apcu\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting apcu_* functions to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "apcu",
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "time": "2021-01-22T09:19:47+00:00"
+            "time": "2021-09-14T05:39:00+00:00"
         }
     ],
     "packages-dev": [],
@@ -190,7 +139,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "ext-redis": "^4.3"
+        "ext-redis": "^5.3.4"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
The base image that phabricator builds upon has been upgraded from Alpine 3.10 to 3.14, and now the version of redis required is 5.3.4 https://repology.org/project/php:redis/versions