### PR TITLE
Landing operations gauge

### DIFF
--- a/src/applications/drydock/storage/DrydockRepositoryOperation.php
+++ b/src/applications/drydock/storage/DrydockRepositoryOperation.php
@@ -12,6 +12,11 @@ final class DrydockRepositoryOperation extends DrydockDAO
   const STATE_WORK = 'work';
   const STATE_DONE = 'done';
   const STATE_FAIL = 'fail';
+  // TM CHANGES
+  const LAND_OPERATION_METRIC_NAME = 'landing_operations_total';
+  const LAND_OPERATION_METRIC_HELP = 'The number of ongoing landing operations';
+  const LAND_OPERATION_METRIC_LABELS = array('repo');
+  // TM CHANGES END
 
   protected $authorPHID;
   protected $objectPHID;
@@ -34,9 +39,9 @@ final class DrydockRepositoryOperation extends DrydockDAO
       $registry = PhabricatorPrometheusApplication::getRegistry();
       $this->landingMetric = $registry->getOrRegisterGauge(
       self::METRIC_NAMESPACE,
-      'landing_operations_total',
-      'The number of ongoing landing operations',
-      ['repo']
+      self::LAND_OPERATION_METRIC_NAME,
+      self::LAND_OPERATION_METRIC_HELP,
+      self::LAND_OPERATION_METRIC_LABELS
       );
   }
   // TM CHANGES END

--- a/src/applications/drydock/storage/DrydockRepositoryOperation.php
+++ b/src/applications/drydock/storage/DrydockRepositoryOperation.php
@@ -1,0 +1,305 @@
+<?php
+
+/**
+ * Represents a request to perform a repository operation like a merge or
+ * cherry-pick.
+ */
+final class DrydockRepositoryOperation extends DrydockDAO
+  implements
+    PhabricatorPolicyInterface {
+
+  const STATE_WAIT = 'wait';
+  const STATE_WORK = 'work';
+  const STATE_DONE = 'done';
+  const STATE_FAIL = 'fail';
+
+  protected $authorPHID;
+  protected $objectPHID;
+  protected $repositoryPHID;
+  protected $repositoryTarget;
+  protected $operationType;
+  protected $operationState;
+  protected $properties = array();
+  protected $isDismissed;
+
+  private $repository = self::ATTACHABLE;
+  private $object = self::ATTACHABLE;
+  private $implementation = self::ATTACHABLE;
+  private $workingCopyLease = self::ATTACHABLE;
+
+  // TM CHANGES fetching landing gauge
+  private $landingMetric;
+
+  function __construct() {
+      $registry = PhabricatorPrometheusApplication::getRegistry();
+      $this->landingMetric = $registry->getOrRegisterGauge(
+      self::METRIC_NAMESPACE,
+      'landing_operations_total',
+      'The number of ongoing landing operations',
+      ['repo']
+      );
+  }
+  // TM CHANGES END
+
+  public static function initializeNewOperation(
+    DrydockRepositoryOperationType $op) {
+
+    // TM CHANGES
+    $this->landingMetric->inc(['repo' => $repository->getDisplayName()]);
+    // TM CHANGES END
+    return id(new DrydockRepositoryOperation())
+      ->setOperationState(self::STATE_WAIT)
+      ->setOperationType($op->getOperationConstant())
+      ->setIsDismissed(0);
+  }
+
+  protected function getConfiguration() {
+    return array(
+      self::CONFIG_AUX_PHID => true,
+      self::CONFIG_SERIALIZATION => array(
+        'properties' => self::SERIALIZATION_JSON,
+      ),
+      self::CONFIG_COLUMN_SCHEMA => array(
+        'repositoryTarget' => 'bytes',
+        'operationType' => 'text32',
+        'operationState' => 'text32',
+        'isDismissed' => 'bool',
+      ),
+      self::CONFIG_KEY_SCHEMA => array(
+        'key_object' => array(
+          'columns' => array('objectPHID'),
+        ),
+        'key_repository' => array(
+          'columns' => array('repositoryPHID', 'operationState'),
+        ),
+        'key_state' => array(
+          'columns' => array('operationState'),
+        ),
+        'key_author' => array(
+          'columns' => array('authorPHID', 'operationState'),
+        ),
+      ),
+    ) + parent::getConfiguration();
+  }
+
+  public function generatePHID() {
+    return PhabricatorPHID::generateNewPHID(
+      DrydockRepositoryOperationPHIDType::TYPECONST);
+  }
+
+  public function attachRepository(PhabricatorRepository $repository) {
+    $this->repository = $repository;
+    return $this;
+  }
+
+  public function getRepository() {
+    return $this->assertAttached($this->repository);
+  }
+
+  public function attachObject($object) {
+    $this->object = $object;
+    return $this;
+  }
+
+  public function getObject() {
+    return $this->assertAttached($this->object);
+  }
+
+  public function attachImplementation(DrydockRepositoryOperationType $impl) {
+    $this->implementation = $impl;
+    return $this;
+  }
+
+  public function getImplementation() {
+    return $this->implementation;
+  }
+
+  public function getWorkingCopyLease() {
+    return $this->assertAttached($this->workingCopyLease);
+  }
+
+  public function attachWorkingCopyLease(DrydockLease $lease) {
+    $this->workingCopyLease = $lease;
+    return $this;
+  }
+
+  public function hasWorkingCopyLease() {
+    return ($this->workingCopyLease !== self::ATTACHABLE);
+  }
+
+  public function getProperty($key, $default = null) {
+    return idx($this->properties, $key, $default);
+  }
+
+  public function setProperty($key, $value) {
+    $this->properties[$key] = $value;
+    return $this;
+  }
+
+  public static function getOperationStateNameMap() {
+    return array(
+      self::STATE_WAIT => pht('Waiting'),
+      self::STATE_WORK => pht('Working'),
+      self::STATE_DONE => pht('Done'),
+      self::STATE_FAIL => pht('Failed'),
+    );
+  }
+
+  public static function getOperationStateIcon($state) {
+    $map = array(
+      self::STATE_WAIT => 'fa-clock-o',
+      self::STATE_WORK => 'fa-plane ph-spin blue',
+      self::STATE_DONE => 'fa-check green',
+      self::STATE_FAIL => 'fa-times red',
+    );
+
+    return idx($map, $state, null);
+  }
+
+  public static function getOperationStateName($state) {
+    $map = self::getOperationStateNameMap();
+    return idx($map, $state, pht('<Unknown: %s>', $state));
+  }
+
+  public function scheduleUpdate() {
+    PhabricatorWorker::scheduleTask(
+      'DrydockRepositoryOperationUpdateWorker',
+      array(
+        'operationPHID' => $this->getPHID(),
+      ),
+      array(
+        'objectPHID' => $this->getPHID(),
+        'priority' => PhabricatorWorker::PRIORITY_ALERTS,
+      ));
+  }
+
+  public function applyOperation(DrydockInterface $interface) {
+    $impl = $this->getImplementation();
+    $impl->setInterface($interface);
+    return $impl->applyOperation($this, $interface);
+  }
+
+  public function getOperationDescription(PhabricatorUser $viewer) {
+    return $this->getImplementation()->getOperationDescription(
+      $this,
+      $viewer);
+  }
+
+  public function getOperationCurrentStatus(PhabricatorUser $viewer) {
+    return $this->getImplementation()->getOperationCurrentStatus(
+      $this,
+      $viewer);
+  }
+
+  public function isUnderway() {
+    switch ($this->getOperationState()) {
+      case self::STATE_WAIT:
+      case self::STATE_WORK:
+        return true;
+    }
+
+    return false;
+  }
+
+  public function isDone() {
+    return ($this->getOperationState() === self::STATE_DONE);
+  }
+
+  public function getWorkingCopyMerges() {
+    return $this->getImplementation()->getWorkingCopyMerges(
+      $this);
+  }
+
+  public function setWorkingCopyLeasePHID($lease_phid) {
+    return $this->setProperty('exec.leasePHID', $lease_phid);
+  }
+
+  public function getWorkingCopyLeasePHID() {
+    return $this->getProperty('exec.leasePHID');
+  }
+
+  public function setCommandError(array $error) {
+    return $this->setProperty('exec.workingcopy.error', $error);
+  }
+
+  public function getCommandError() {
+    return $this->getProperty('exec.workingcopy.error');
+  }
+
+  public function logText($text) {
+    return $this->logEvent(
+      DrydockTextLogType::LOGCONST,
+      array(
+        'text' => $text,
+      ));
+  }
+
+  public function logEvent($type, array $data = array()) {
+    $log = id(new DrydockLog())
+      ->setEpoch(PhabricatorTime::getNow())
+      ->setType($type)
+      ->setData($data);
+
+    $log->setOperationPHID($this->getPHID());
+
+    if ($this->hasWorkingCopyLease()) {
+      $lease = $this->getWorkingCopyLease();
+      $log->setLeasePHID($lease->getPHID());
+
+      $resource_phid = $lease->getResourcePHID();
+      if ($resource_phid) {
+        $resource = $lease->getResource();
+
+        $log->setResourcePHID($resource->getPHID());
+        $log->setBlueprintPHID($resource->getBlueprintPHID());
+      }
+    }
+
+    return $log->save();
+  }
+
+
+/* -(  PhabricatorPolicyInterface  )----------------------------------------- */
+
+
+  public function getCapabilities() {
+    return array(
+      PhabricatorPolicyCapability::CAN_VIEW,
+      PhabricatorPolicyCapability::CAN_EDIT,
+    );
+  }
+
+  public function getPolicy($capability) {
+    $need_capability = $this->getRequiredRepositoryCapability($capability);
+
+    return $this->getRepository()
+      ->getPolicy($need_capability);
+  }
+
+  public function hasAutomaticCapability($capability, PhabricatorUser $viewer) {
+    $need_capability = $this->getRequiredRepositoryCapability($capability);
+
+    return $this->getRepository()
+      ->hasAutomaticCapability($need_capability, $viewer);
+  }
+
+  public function describeAutomaticCapability($capability) {
+    return pht(
+      'A repository operation inherits the policies of the repository it '.
+      'affects.');
+  }
+
+  private function getRequiredRepositoryCapability($capability) {
+    // To edit a RepositoryOperation, require that the user be able to push
+    // to the repository.
+
+    $map = array(
+      PhabricatorPolicyCapability::CAN_EDIT =>
+        DiffusionPushCapability::CAPABILITY,
+    );
+
+    return idx($map, $capability, $capability);
+  }
+
+
+}

--- a/src/applications/drydock/worker/DrydockRepositoryOperationUpdateWorker.php
+++ b/src/applications/drydock/worker/DrydockRepositoryOperationUpdateWorker.php
@@ -10,9 +10,9 @@ final class DrydockRepositoryOperationUpdateWorker
       $registry = PhabricatorPrometheusApplication::getRegistry();
       $this->landingMetric = $registry->getOrRegisterGauge(
       self::METRIC_NAMESPACE,
-      'landing_operations_total',
-      'The number of ongoing landing operations',
-      ['repo']
+      DrydockRepositoryOperation::LAND_OPERATION_METRIC_NAME,
+      DrydockRepositoryOperation::LAND_OPERATION_METRIC_HELP,
+      DrydockRepositoryOperation::LAND_OPERATION_METRIC_LABELS
       );
   }
   // TM CHANGES END

--- a/src/applications/drydock/worker/DrydockRepositoryOperationUpdateWorker.php
+++ b/src/applications/drydock/worker/DrydockRepositoryOperationUpdateWorker.php
@@ -1,0 +1,205 @@
+<?php
+
+final class DrydockRepositoryOperationUpdateWorker
+  extends DrydockWorker {
+
+  // TM CHANGES fetching landing gauge
+  private $landingMetric;
+
+  function __construct() {
+      $registry = PhabricatorPrometheusApplication::getRegistry();
+      $this->landingMetric = $registry->getOrRegisterGauge(
+      self::METRIC_NAMESPACE,
+      'landing_operations_total',
+      'The number of ongoing landing operations',
+      ['repo']
+      );
+  }
+  // TM CHANGES END
+
+  protected function doWork() {
+    $operation_phid = $this->getTaskDataValue('operationPHID');
+
+    $hash = PhabricatorHash::digestForIndex($operation_phid);
+    $lock_key = 'drydock.operation:'.$hash;
+
+    $lock = PhabricatorGlobalLock::newLock($lock_key)
+      ->lock(1);
+
+    try {
+      $operation = $this->loadOperation($operation_phid);
+      $this->handleUpdate($operation);
+    } catch (Exception $ex) {
+      $lock->unlock();
+      throw $ex;
+    }
+
+    $lock->unlock();
+  }
+
+
+  private function handleUpdate(DrydockRepositoryOperation $operation) {
+    $operation_state = $operation->getOperationState();
+
+    switch ($operation_state) {
+      case DrydockRepositoryOperation::STATE_WAIT:
+        $operation
+          ->setOperationState(DrydockRepositoryOperation::STATE_WORK)
+          ->save();
+        break;
+      case DrydockRepositoryOperation::STATE_WORK:
+        break;
+      case DrydockRepositoryOperation::STATE_DONE:
+      case DrydockRepositoryOperation::STATE_FAIL:
+        // No more processing for these requests.
+        return;
+    }
+
+    // TODO: We should probably check for other running operations with lower
+    // IDs and the same repository target and yield to them here? That is,
+    // enforce sequential evaluation of operations against the same target so
+    // that if you land "A" and then land "B", we always finish "A" first.
+    // For now, just let stuff happen in any order. We can't lease until
+    // we know we're good to move forward because we might deadlock if we do:
+    // we're waiting for another operation to complete, and that operation is
+    // waiting for a lease we're holding.
+
+    try {
+      $lease = $this->loadWorkingCopyLease($operation);
+
+      $interface = $lease->getInterface(
+        DrydockCommandInterface::INTERFACE_TYPE);
+
+      // No matter what happens here, destroy the lease away once we're done.
+      $lease->setReleaseOnDestruction(true);
+
+      $operation->attachWorkingCopyLease($lease);
+
+      $operation->logEvent(DrydockOperationWorkLogType::LOGCONST);
+
+      $operation->applyOperation($interface);
+
+    } catch (PhabricatorWorkerYieldException $ex) {
+      throw $ex;
+    } catch (Exception $ex) {
+      $operation
+        ->setOperationState(DrydockRepositoryOperation::STATE_FAIL)
+        ->save();
+      throw $ex;
+    }
+
+    $operation
+      ->setOperationState(DrydockRepositoryOperation::STATE_DONE)
+      ->save();
+    // TM CHANGES
+    $this->landingMetric->dec(['repo' => $repository->getDisplayName()]);
+    // TM CHANGES END
+
+    // TODO: Once we have sequencing, we could awaken the next operation
+    // against this target after finishing or failing.
+  }
+
+  private function loadWorkingCopyLease(
+    DrydockRepositoryOperation $operation) {
+    $viewer = $this->getViewer();
+
+    // TODO: This is very similar to leasing in Harbormaster, maybe we can
+    // share some of the logic?
+
+    $working_copy = new DrydockWorkingCopyBlueprintImplementation();
+    $working_copy_type = $working_copy->getType();
+
+    $lease_phid = $operation->getProperty('exec.leasePHID');
+    if ($lease_phid) {
+      $lease = id(new DrydockLeaseQuery())
+        ->setViewer($viewer)
+        ->withPHIDs(array($lease_phid))
+        ->executeOne();
+      if (!$lease) {
+        throw new PhabricatorWorkerPermanentFailureException(
+          pht(
+            'Lease "%s" could not be loaded.',
+            $lease_phid));
+      }
+    } else {
+      $repository = $operation->getRepository();
+
+      $allowed_phids = $repository->getAutomationBlueprintPHIDs();
+      $authorizing_phid = $repository->getPHID();
+
+      $lease = DrydockLease::initializeNewLease()
+        ->setResourceType($working_copy_type)
+        ->setOwnerPHID($operation->getPHID())
+        ->setAuthorizingPHID($authorizing_phid)
+        ->setAllowedBlueprintPHIDs($allowed_phids);
+
+      $map = $this->buildRepositoryMap($operation);
+
+      $lease->setAttribute('repositories.map', $map);
+
+      $task_id = $this->getCurrentWorkerTaskID();
+      if ($task_id) {
+        $lease->setAwakenTaskIDs(array($task_id));
+      }
+
+      $operation
+        ->setWorkingCopyLeasePHID($lease->getPHID())
+        ->save();
+
+      $lease->queueForActivation();
+    }
+
+    if ($lease->isActivating()) {
+      throw new PhabricatorWorkerYieldException(15);
+    }
+
+    if (!$lease->isActive()) {
+      $vcs_error = $working_copy->getCommandError($lease);
+      if ($vcs_error) {
+        $operation
+          ->setCommandError($vcs_error)
+          ->save();
+      }
+
+      throw new PhabricatorWorkerPermanentFailureException(
+        pht(
+          'Lease "%s" never activated.',
+          $lease->getPHID()));
+    }
+
+    return $lease;
+  }
+
+  private function buildRepositoryMap(DrydockRepositoryOperation $operation) {
+    $repository = $operation->getRepository();
+
+    $target = $operation->getRepositoryTarget();
+    list($type, $name) = explode(':', $target, 2);
+    switch ($type) {
+      case 'branch':
+        $spec = array(
+          'branch' => $name,
+        );
+        break;
+      case 'none':
+        $spec = array();
+        break;
+      default:
+        throw new Exception(
+          pht(
+            'Unknown repository operation target type "%s" (in target "%s").',
+            $type,
+            $target));
+    }
+
+    $spec['merges'] = $operation->getWorkingCopyMerges();
+
+    $map = array();
+    $map[$repository->getCloneName()] = array(
+      'phid' => $repository->getPHID(),
+      'default' => true,
+    ) + $spec;
+
+    return $map;
+  }
+}

--- a/src/applications/drydock/worker/DrydockRepositoryOperationUpdateWorker.php
+++ b/src/applications/drydock/worker/DrydockRepositoryOperationUpdateWorker.php
@@ -85,6 +85,9 @@ final class DrydockRepositoryOperationUpdateWorker
       $operation
         ->setOperationState(DrydockRepositoryOperation::STATE_FAIL)
         ->save();
+      // TM CHANGES
+      $this->landingMetric->dec(['repo' => $repository->getDisplayName()]);
+      // TM CHANGES END
       throw $ex;
     }
 


### PR DESCRIPTION
Changes indicated with `// TM CHANGES`

Gauge to track the number of ongoing landing operations (those either in the queue or currently being landed). The intention is to create an alert when this number gets too high.

This increments the gauge whenever a landing operation is transitioned to state `STATE_WAIT`, and decrements it when it transitions to either `STATE_DONE` or `STATE_FAIL`. We could separately add a counter for the number of failed operations.

