### PR TITLE
Delete all tmp-drydock branches

### DIFF
--- a/src/applications/drydock/blueprint/DrydockWorkingCopyBlueprintImplementation.php
+++ b/src/applications/drydock/blueprint/DrydockWorkingCopyBlueprintImplementation.php
@@ -8,6 +8,7 @@ final class DrydockWorkingCopyBlueprintImplementation
   const PHASE_MERGEFETCH = 'blueprint.workingcopy.fetch.staging';
   // TM CHANGES BEGIN
   const PHASE_MERGEREBASE = 'blueprint.workingcopy.rebase';
+  const TMP_BRANCH_PREFIX = 'tmp-drydock';
   // TM CHANGES END
 
   public function isEnabled() {
@@ -523,7 +524,10 @@ final class DrydockWorkingCopyBlueprintImplementation
     // TM CHANGES BEGIN
     // We try to rebase the diff off the branch we are trying land on.
     // this means we can drop any commits which have already been landed.
-    $tmp_branch_name = sprintf('tmp-branch-%d', rand());
+    $tmp_branch_name = sprintf(
+      '%s-%d',
+      self::GIT_BRANCH_PREFIX,
+      rand());
     try {
       $interface->execx(
         'git checkout -b %s %s',
@@ -556,8 +560,8 @@ final class DrydockWorkingCopyBlueprintImplementation
         return;
       } catch (CommandException $ex) {
         $interface->execx(
-          'git branch -D %s',
-          $tmp_branch_name);
+          'git branch -D `git branch | grep -E "%s-.*"`',
+          self::GIT_BRANCH_PREFIX);
         $display_command = csprintf(
           'git merge --squash %R',
           $src_ref);
@@ -596,8 +600,8 @@ final class DrydockWorkingCopyBlueprintImplementation
       $interface->execx('%C', $real_command);
     } catch (CommandException $ex) {
       $interface->execx(
-        'git branch -D %s',
-        $tmp_branch_name);
+        'git branch -D `git branch | grep -E "%s-.*"`',
+        self::GIT_BRANCH_PREFIX);
       
       // display the full rebase command so the user can debug the full flow
       $display_command = csprintf(
@@ -615,8 +619,8 @@ final class DrydockWorkingCopyBlueprintImplementation
     }
 
     $interface->execx(
-      'git branch -D %s',
-      $tmp_branch_name);
+      'git branch -D `git branch | grep -E "%s-.*"`',
+      self::GIT_BRANCH_PREFIX);
 
     // TM CHANGES END
   }

--- a/src/applications/drydock/blueprint/DrydockWorkingCopyBlueprintImplementation.php
+++ b/src/applications/drydock/blueprint/DrydockWorkingCopyBlueprintImplementation.php
@@ -7,7 +7,6 @@ final class DrydockWorkingCopyBlueprintImplementation
   const PHASE_REMOTEFETCH = 'blueprint.workingcopy.fetch.remote';
   const PHASE_MERGEFETCH = 'blueprint.workingcopy.fetch.staging';
   // TM CHANGES BEGIN
-  const PHASE_MERGEREBASE = 'blueprint.workingcopy.rebase';
   const TMP_BRANCH_PREFIX = 'tmp-drydock';
   // TM CHANGES END
 
@@ -539,7 +538,7 @@ final class DrydockWorkingCopyBlueprintImplementation
         $tmp_branch_name,
         $src_ref);
       $error = DrydockCommandError::newFromCommandException($ex)
-        ->setPhase(self::PHASE_MERGEFETCH)
+        ->setPhase(self::PHASE_SQUASHMERGE)
         ->setDisplayCommand($display_command);
       $lease->setAttribute('workingcopy.vcs.error', $error->toDictionary());
 
@@ -557,7 +556,6 @@ final class DrydockWorkingCopyBlueprintImplementation
           'drydock',
           'drydock@phabricator',
           $src_ref);
-        return;
       } catch (CommandException $ex) {
         $interface->execx(
           'git branch -D `git branch | grep -E "%s-.*"`',
@@ -573,6 +571,10 @@ final class DrydockWorkingCopyBlueprintImplementation
         $lease->setAttribute('workingcopy.vcs.error', $error->toDictionary());
         throw $ex;
       }
+      $interface->execx(
+        'git branch -D `git branch | grep -E "%s-.*"`',
+        self::GIT_BRANCH_PREFIX);
+      return;
     }
 
     try {
@@ -580,7 +582,7 @@ final class DrydockWorkingCopyBlueprintImplementation
     } catch (CommandException $ex) {
       
       $error = DrydockCommandError::newFromCommandException($ex)
-        ->setPhase(self::PHASE_MERGEREBASE)
+        ->setPhase(self::PHASE_SQUASHMERGE)
         ->setDisplayCommand('git checkout -');
       $lease->setAttribute('workingcopy.vcs.error', $error->toDictionary());
 

--- a/src/applications/drydock/blueprint/DrydockWorkingCopyBlueprintImplementation.php
+++ b/src/applications/drydock/blueprint/DrydockWorkingCopyBlueprintImplementation.php
@@ -525,7 +525,7 @@ final class DrydockWorkingCopyBlueprintImplementation
     // this means we can drop any commits which have already been landed.
     $tmp_branch_name = sprintf(
       '%s-%d',
-      self::GIT_BRANCH_PREFIX,
+      self::TMP_BRANCH_PREFIX,
       rand());
     try {
       $interface->execx(
@@ -568,13 +568,13 @@ final class DrydockWorkingCopyBlueprintImplementation
         $lease->setAttribute('workingcopy.vcs.error', $error->toDictionary());
         $interface->execx(
           'git branch -D `git branch | grep -E "%s-.*"`',
-          self::GIT_BRANCH_PREFIX);
+          self::TMP_BRANCH_PREFIX);
         throw $ex;
       }
       try {
         $interface->execx(
           'git branch -D `git branch | grep -E "%s-.*"`',
-          self::GIT_BRANCH_PREFIX);
+          self::TMP_BRANCH_PREFIX);
       } catch (CommandExeption $ex) {
         // ignore it we were just trying to tidy up after ourselves
       }
@@ -619,7 +619,7 @@ final class DrydockWorkingCopyBlueprintImplementation
       $lease->setAttribute('workingcopy.vcs.error', $error->toDictionary());
       $interface->execx(
         'git branch -D `git branch | grep -E "%s-.*"`',
-        self::GIT_BRANCH_PREFIX);
+        self::TMP_BRANCH_PREFIX);
 
       throw $ex;
     }
@@ -627,7 +627,7 @@ final class DrydockWorkingCopyBlueprintImplementation
     try {
       $interface->execx(
         'git branch -D `git branch | grep -E "%s-.*"`',
-        self::GIT_BRANCH_PREFIX);
+        self::TMP_BRANCH_PREFIX);
     } catch (CommandExeption $ex) {
       // ignore it we were just trying to tidy up after ourselves
     }


### PR DESCRIPTION
Use a regex to delete all tmp-drydock branches. The git delete might have failed previously so we clean all branches in the working copy including ones that might have been created in a previous lease. Also moving branch deletions after helpful error creations so we are less likely to see unhelpful cryptic error messages. If the merge is fully succesful we catch and continue on exception when cleaning up after ourselves by deleting a branch - The next time we will catch this with the branch deletion regex.