### PR TITLE
abort rebase if we fail the rebase

### DIFF
--- a/src/applications/drydock/blueprint/DrydockWorkingCopyBlueprintImplementation.php
+++ b/src/applications/drydock/blueprint/DrydockWorkingCopyBlueprintImplementation.php
@@ -552,7 +552,7 @@ final class DrydockWorkingCopyBlueprintImplementation
       // If we fail to rebase we insted do the original squash merge without rebase
       try {
         $interface->execx(
-          'git checkout - && git -c user.name=%s -c user.email=%s merge --no-stat --squash -- %s',
+          'git rebase --abort && git checkout - && git -c user.name=%s -c user.email=%s merge --no-stat --squash -- %s',
           'drydock',
           'drydock@phabricator',
           $src_ref);


### PR DESCRIPTION
previously we weren't aborting the rebase if we failed to rebase which was leaving the working copy in a bad state