### PR TITLE
adding -C and -w flag to git blame which ignores moving lines between files and white spaces

### DIFF
--- a/src/__phutil_library_map__.php
+++ b/src/__phutil_library_map__.php
@@ -11,6 +11,7 @@ phutil_register_library_map(array(
   'class' => array(
     'DifferentialRevisionEditEngine' => 'applications/differential/editor/DifferentialRevisionEditEngine.php',
     'DifferentialRevisionViewController' => 'applications/differential/controller/DifferentialRevisionViewController.php',
+    'DiffusionGitBlameQuery' => 'applications/diffusion/query/blame/DiffusionGitBlameQuery.php',
     'DiffusionGitUploadArchiveSSHWorkflow' => 'applications/diffusion/ssh/DiffusionGitUploadArchiveSSHWorkflow.php',
     'DiffusionPushLogBuildableEngine' => 'applications/diffusion/harbormaster/DiffusionPushLogBuildableEngine.php',
     'DiffusionPushLogBuildableTransaction' => 'applications/diffusion/xaction/DiffusionPushLogBuildableTransaction.php',
@@ -40,6 +41,7 @@ phutil_register_library_map(array(
   'xmap' => array(
     'DifferentialRevisionEditEngine' => 'PhabricatorEditEngine',
     'DifferentialRevisionViewController' => 'DifferentialController',
+    'DiffusionGitBlameQuery' => 'DiffusionBlameQuery',
     'DiffusionGitUploadArchiveSSHWorkflow' => 'DiffusionGitSSHWorkflow',
     'DiffusionPushLogBuildableEngine' => 'HarbormasterBuildableEngine',
     'DiffusionPushLogBuildableTransaction' => 'PhabricatorModularTransactionType',

--- a/src/applications/diffusion/query/blame/DiffusionGitBlameQuery.php
+++ b/src/applications/diffusion/query/blame/DiffusionGitBlameQuery.php
@@ -13,7 +13,7 @@ final class DiffusionGitBlameQuery extends DiffusionBlameQuery {
 
     // TM CHANGES
     return $repository->getLocalCommandFuture(
-      '--no-pager blame --root -s -l -C %s -- %s',
+      '--no-pager blame --root -s -l -C -w %s -- %s',
       gitsprintf('%s', $commit),
       $path);
     // TM CHANGES END

--- a/src/applications/diffusion/query/blame/DiffusionGitBlameQuery.php
+++ b/src/applications/diffusion/query/blame/DiffusionGitBlameQuery.php
@@ -1,0 +1,40 @@
+<?php
+
+final class DiffusionGitBlameQuery extends DiffusionBlameQuery {
+
+  protected function newBlameFuture(DiffusionRequest $request, $path) {
+    $repository = $request->getRepository();
+
+    $commit = $request->getCommit();
+
+    // NOTE: The "--root" flag suppresses the addition of the "^" boundary
+    // commit marker. Without it, root commits render with a "^" before them,
+    // and one fewer character of the commit hash.
+
+    // TM CHANGES
+    return $repository->getLocalCommandFuture(
+      '--no-pager blame --root -s -l -C %s -- %s',
+      gitsprintf('%s', $commit),
+      $path);
+    // TM CHANGES END
+  }
+
+  protected function resolveBlameFuture(ExecFuture $future) {
+    list($err, $stdout) = $future->resolve();
+
+    if ($err) {
+      return null;
+    }
+
+    $result = array();
+
+    $lines = phutil_split_lines($stdout);
+    foreach ($lines as $line) {
+      list($commit) = explode(' ', $line, 2);
+      $result[] = $commit;
+    }
+
+    return $result;
+  }
+
+}


### PR DESCRIPTION
https://git-scm.com/docs/git-blame#Documentation/git-blame.txt--Cltnumgt 

> In addition to -M, detect lines moved or copied from other files that were modified in the same commit. This is useful when you reorganize your program and move code around across files. When this option is given twice, the command additionally looks for copies from other files in the commit that creates the file. When this option is given three times, the command additionally looks for copies from other files in any commit.

The performance of git blame looks largely unaffected by adding the flag once but more than once takes a lot longer

https://git-scm.com/docs/git-blame#Documentation/git-blame.txt--w

>Ignore whitespace when comparing the parent’s version and the child’s to find where the lines came from.