### PR TITLE
remove diff onto herald field and add revision onto herald field

### DIFF
--- a/src/__phutil_library_map__.php
+++ b/src/__phutil_library_map__.php
@@ -9,8 +9,8 @@
 phutil_register_library_map(array(
   '__library_version__' => 2,
   'class' => array(
-    'DifferentialDiffOntoField' => 'applications/differential/herald/DifferentialDiffOntoField.php',
     'DifferentialRevisionEditEngine' => 'applications/differential/editor/DifferentialRevisionEditEngine.php',
+    'DifferentialRevisionTitleHeraldField' => 'applications/differential/herald/DifferentialRevisionOntoField.php',
     'DifferentialRevisionViewController' => 'applications/differential/controller/DifferentialRevisionViewController.php',
     'DiffusionGitBlameQuery' => 'applications/diffusion/query/blame/DiffusionGitBlameQuery.php',
     'DiffusionGitUploadArchiveSSHWorkflow' => 'applications/diffusion/ssh/DiffusionGitUploadArchiveSSHWorkflow.php',
@@ -18,6 +18,7 @@ phutil_register_library_map(array(
     'DiffusionPushLogBuildableTransaction' => 'applications/diffusion/xaction/DiffusionPushLogBuildableTransaction.php',
     'DiffusionRepositoryClusterEngine' => 'applications/diffusion/protocol/DiffusionRepositoryClusterEngine.php',
     'DrydockWorkingCopyBlueprintImplementation' => 'applications/drydock/blueprint/DrydockWorkingCopyBlueprintImplementation.php',
+    'HeraldDifferentialRevisionAdapter' => 'applications/differential/herald/HeraldDifferentialRevisionAdapter.php',
     'HeraldPreCommitRefAdapter' => 'applications/diffusion/herald/HeraldPreCommitRefAdapter.php',
     'PhabricatorAphlictManagementForegroundWorkflow' => 'applications/aphlict/management/PhabricatorAphlictManagementForegroundWorkflow.php',
     'PhabricatorAuthProvider' => 'applications/auth/provider/PhabricatorAuthProvider.php',
@@ -40,8 +41,8 @@ phutil_register_library_map(array(
   ),
   'function' => array(),
   'xmap' => array(
-    'DifferentialDiffOntoField' => 'DifferentialDiffHeraldField',
     'DifferentialRevisionEditEngine' => 'PhabricatorEditEngine',
+    'DifferentialRevisionTitleHeraldField' => 'DifferentialRevisionHeraldField',
     'DifferentialRevisionViewController' => 'DifferentialController',
     'DiffusionGitBlameQuery' => 'DiffusionBlameQuery',
     'DiffusionGitUploadArchiveSSHWorkflow' => 'DiffusionGitSSHWorkflow',
@@ -49,6 +50,10 @@ phutil_register_library_map(array(
     'DiffusionPushLogBuildableTransaction' => 'PhabricatorModularTransactionType',
     'DiffusionRepositoryClusterEngine' => 'Phobject',
     'DrydockWorkingCopyBlueprintImplementation' => 'DrydockBlueprintImplementation',
+    'HeraldDifferentialRevisionAdapter' => array(
+      'HeraldDifferentialAdapter',
+      'HarbormasterBuildableAdapterInterface',
+    ),
     'HeraldPreCommitRefAdapter' => array(
       'HeraldPreCommitAdapter',
       'HarbormasterBuildableAdapterInterface',

--- a/src/applications/differential/herald/DifferentialRevisionOntoField.php
+++ b/src/applications/differential/herald/DifferentialRevisionOntoField.php
@@ -1,19 +1,20 @@
-i<?php
+<?php
 
-final class DifferentialDiffOntoField
-  extends DifferentialDiffHeraldField {
+final class DifferentialRevisionTitleHeraldField
+  extends DifferentialRevisionHeraldField {
 
-  const FIELDCONST = 'differential.diff.refs.onto';
+  const FIELDCONST = 'differential.revision.onto';
 
   public function getHeraldFieldName() {
     return pht('Onto branch');
   }
 
   public function getHeraldFieldValue($object) {
-    return $object->loadTargetBranch();
+    return $this->getAdapter()->getOntoBranch();
   }
 
   protected function getHeraldFieldStandardType() {
     return self::STANDARD_TEXT;
   }
+
 }

--- a/src/applications/differential/herald/HeraldDifferentialRevisionAdapter.php
+++ b/src/applications/differential/herald/HeraldDifferentialRevisionAdapter.php
@@ -1,0 +1,164 @@
+<?php
+
+final class HeraldDifferentialRevisionAdapter
+  extends HeraldDifferentialAdapter
+  implements HarbormasterBuildableAdapterInterface {
+
+  protected $revision;
+
+  protected $affectedPackages;
+  protected $changesets;
+  private $haveHunks;
+
+  private $buildRequests = array();
+
+  public function getAdapterApplicationClass() {
+    return PhabricatorDifferentialApplication::class;
+  }
+
+  protected function newObject() {
+    return new DifferentialRevision();
+  }
+
+  public function isTestAdapterForObject($object) {
+    return ($object instanceof DifferentialRevision);
+  }
+
+  public function getAdapterTestDescription() {
+    return pht(
+      'Test rules which run when a revision is created or updated.');
+  }
+
+  public function newTestAdapter(PhabricatorUser $viewer, $object) {
+    return self::newLegacyAdapter(
+      $object,
+      $object->loadActiveDiff());
+  }
+
+  protected function initializeNewAdapter() {
+    $this->revision = $this->newObject();
+  }
+
+  // TM CHANGES START
+  public function getOntoBranch() {
+    $this->getDiff()->loadTargetBranch();
+  }
+  // TM CHANGES END
+
+  public function getObject() {
+    return $this->revision;
+  }
+
+  public function getAdapterContentType() {
+    return 'differential';
+  }
+
+  public function getAdapterContentName() {
+    return pht('Differential Revisions');
+  }
+
+  public function getAdapterContentDescription() {
+    return pht(
+      "React to revisions being created or updated.\n".
+      "Revision rules can send email, flag revisions, add reviewers, ".
+      "and run build plans.");
+  }
+
+  public function supportsRuleType($rule_type) {
+    switch ($rule_type) {
+      case HeraldRuleTypeConfig::RULE_TYPE_GLOBAL:
+      case HeraldRuleTypeConfig::RULE_TYPE_PERSONAL:
+        return true;
+      case HeraldRuleTypeConfig::RULE_TYPE_OBJECT:
+      default:
+        return false;
+    }
+  }
+
+  public static function newLegacyAdapter(
+    DifferentialRevision $revision,
+    DifferentialDiff $diff) {
+    $object = new HeraldDifferentialRevisionAdapter();
+
+    // Reload the revision to pick up relationship information.
+    $revision = id(new DifferentialRevisionQuery())
+      ->withIDs(array($revision->getID()))
+      ->setViewer(PhabricatorUser::getOmnipotentUser())
+      ->needReviewers(true)
+      ->executeOne();
+
+    $object->revision = $revision;
+    $object->setDiff($diff);
+
+    return $object;
+  }
+
+  public function getHeraldName() {
+    return $this->revision->getTitle();
+  }
+
+  protected function loadChangesets() {
+    if ($this->changesets === null) {
+      $this->changesets = $this->getDiff()->loadChangesets();
+    }
+    return $this->changesets;
+  }
+
+  protected function loadChangesetsWithHunks() {
+    $changesets = $this->loadChangesets();
+
+    if ($changesets && !$this->haveHunks) {
+      $this->haveHunks = true;
+
+      id(new DifferentialHunkQuery())
+        ->setViewer(PhabricatorUser::getOmnipotentUser())
+        ->withChangesets($changesets)
+        ->needAttachToChangesets(true)
+        ->execute();
+    }
+
+    return $changesets;
+  }
+
+  public function loadAffectedPackages() {
+    if ($this->affectedPackages === null) {
+      $this->affectedPackages = array();
+
+      $repository = $this->loadRepository();
+      if ($repository) {
+        $packages = PhabricatorOwnersPackage::loadAffectedPackagesForChangesets(
+          $repository,
+          $this->getDiff(),
+          $this->loadChangesets());
+        $this->affectedPackages = $packages;
+      }
+    }
+    return $this->affectedPackages;
+  }
+
+  public function loadReviewers() {
+    return $this->getObject()->getReviewerPHIDs();
+  }
+
+
+/* -(  HarbormasterBuildableAdapterInterface  )------------------------------ */
+
+
+  public function getHarbormasterBuildablePHID() {
+    return $this->getDiff()->getPHID();
+  }
+
+  public function getHarbormasterContainerPHID() {
+    return $this->getObject()->getPHID();
+  }
+
+  public function getQueuedHarbormasterBuildRequests() {
+    return $this->buildRequests;
+  }
+
+  public function queueHarbormasterBuildRequest(
+    HarbormasterBuildRequest $request) {
+    $this->buildRequests[] = $request;
+  }
+
+}


### PR DESCRIPTION
The Diff herald rules are evaluated on new diffs uploaded as part of the conduit differential.creatediff which doesn't have the capability to send onto branch information. This means we can't use herald rules on onto branches since we don't have the onto branch yet. Revisions do have the onto branch available to them so create a herald field for revisions instead.