### PR TITLE
add function to query for viewerpackages

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ should find them.
    * Added herald rules and harbourmaster builds for refs
  * Drydock
    * Modified the working copy blueprint to rebase before trying to merge.
+ * Owners
+   * Added a query function to query current viewers packages
  * Prometheus
    * Added prometheus metric infrastructure and application.
    * Added phabricator up metric to indicate whether phabricator is up or not.

--- a/src/applications/owners/typeahead/PhabricatorOwnersPackageFunctionDatasource.php
+++ b/src/applications/owners/typeahead/PhabricatorOwnersPackageFunctionDatasource.php
@@ -1,0 +1,28 @@
+<?php
+
+final class PhabricatorOwnersPackageFunctionDatasource
+  extends PhabricatorTypeaheadCompositeDatasource {
+
+  public function getBrowseTitle() {
+    return pht('Browse Packages');
+  }
+
+  public function getPlaceholderText() {
+    return pht('Type a package name or function...');
+  }
+
+  public function getDatasourceApplicationClass() {
+    return PhabricatorOwnersApplication::class;
+  }
+
+  public function getComponentDatasources() {
+    return array(
+      new PhabricatorOwnersPackageDatasource(),
+      new PhabricatorOwnersPackageOwnerDatasource(),
+      // TM CHANGES
+      new PhabricatorOwnersPackageViewerOwnerDatasource(),
+      // TM CHANGES END
+    );
+  }
+
+}

--- a/src/applications/owners/typeahead/PhabricatorOwnersPackageViewerOwnerDatasource.php
+++ b/src/applications/owners/typeahead/PhabricatorOwnersPackageViewerOwnerDatasource.php
@@ -1,0 +1,83 @@
+<?php
+
+final class PhabricatorOwnersPackageOwnerDatasource
+  extends PhabricatorTypeaheadDatasource {
+
+  public function getBrowseTitle() {
+    return pht('Browse Packages owned by viewer');
+  }
+
+  public function getPlaceholderText() {
+    return pht('Type viewerpackages()...');
+  }
+
+  public function getDatasourceApplicationClass() {
+    return PhabricatorOwnersApplication::class;
+  }
+
+  public function getDatasourceFunctions() {
+    return array(
+      'packages' => array(
+        'name' => pht('Viewer Packages'),
+        'summary' => pht("Find results in any of a viewer's packages."),
+        'description' => pht(
+          "This function allows you to find results associated with any ".
+          "of the packages of the current viewer. ".
+      ),
+    );
+  }
+
+  public function loadResults() {
+    if ($this->getViewer()->getPHID()) {
+      $results = array($this->renderViewerFunctionToken());
+    } else {
+      $results = array();
+    }
+
+    return $this->filterResultsAgainstTokens($results);
+  }
+
+  protected function canEvaluateFunction($function) {
+    if (!$this->getViewer()->getPHID()) {
+      return false;
+    }
+
+    return parent::canEvaluateFunction($function);
+  }
+
+  protected function evaluateFunction($function, array $argv_list) {
+    $phids = array();
+    foreach ($argv_list as $argv) {
+      $phids[] = $this->getViewer()->getPHID();
+    }
+
+    if ($phids) {
+      $packages = id(new PhabricatorOwnersPackageQuery())
+        ->setViewer($this->getViewer())
+        ->withOwnerPHIDs($phids)
+        ->execute();
+      foreach ($packages as $package) {
+        $phids[] = $package->getPHID();
+      }
+    }
+
+    return $phids;
+  }
+
+  public function renderFunctionTokens($function, array $argv_list) {
+    $tokens = array();
+    foreach ($argv_list as $argv) {
+      $tokens[] = PhabricatorTypeaheadTokenView::newFromTypeaheadResult(
+        $this->renderViewerFunctionToken());
+    }
+    return $tokens;
+  }
+
+  private function renderViewerFunctionToken() {
+    return $this->newFunctionResult()
+      ->setName(pht('Current Viewer'))
+      ->setPHID('viewerpackages()')
+      ->setIcon('fa-user')
+      ->setUnique(true);
+  }
+}


### PR DESCRIPTION
This change adds the function viewerpackages() which should allow us to query revisions and packages that the viewer is an owner of. This is similar to the responsible query but that also includes revisions that the viewer has authored